### PR TITLE
Remove deprecated compiler check

### DIFF
--- a/Formula/vowpal-wabbit-7.10.rb
+++ b/Formula/vowpal-wabbit-7.10.rb
@@ -16,7 +16,6 @@ class VowpalWabbit710 < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  needs :cxx11
 
   def install
     ENV.cxx11

--- a/Formula/vowpal-wabbit-8.2.1.rb
+++ b/Formula/vowpal-wabbit-8.2.1.rb
@@ -22,7 +22,6 @@ class VowpalWabbit821 < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  needs :cxx11
 
   def install
     ENV.cxx11


### PR DESCRIPTION
As of brew 2.0.0, this compiler check is deprecated. See:
https://github.com/Homebrew/homebrew-core/pull/36362

When trying to `bin/install` in e.g. _web_, one sees messages like:
```
Error: Invalid formula: .../Formula/vowpal-wabbit-7.10.rb
Calling needs :cxx11 is disabled! There is no replacement.
Please report this to the opendoor-labs/tap tap:
  .../opendoor-labs/homebrew-tap/Formula/vowpal-wabbit-7.10.rb:19
```

I have tested this change locally by running `brew install ./Formula/{vowpal-wabbit-7.10.rb,vowpal-wabbit-8.2.1.rb}` from this branch.

## TODO
- [ ] Are any engineers running a MacOS version before Mavericks?