### PR TITLE
add kafka@2.3.0, zookeeper@3.4.14

### DIFF
--- a/Formula/kafka@2.3.0.rb
+++ b/Formula/kafka@2.3.0.rb
@@ -1,0 +1,117 @@
+class Kafka < Formula
+  desc "Publish-subscribe messaging rethought as a distributed commit log"
+  homepage "https://kafka.apache.org/"
+  url "https://www.apache.org/dyn/closer.cgi?path=/kafka/2.3.0/kafka_2.12-2.3.0.tgz"
+  sha256 "d86f5121a9f0c44477ae6b6f235daecc3f04ecb7bf98596fd91f402336eee3e7"
+
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "1483beca512a1121491d8890290826e80f87d6630c37b15207db1d0cf39c805c" => :mojave
+    sha256 "1483beca512a1121491d8890290826e80f87d6630c37b15207db1d0cf39c805c" => :high_sierra
+    sha256 "84e51f5c33a35333e3da125076fa9f566e647ff9a555716ac478123a81d4186b" => :sierra
+  end
+
+  # Related to https://issues.apache.org/jira/browse/KAFKA-2034
+  # Since Kafka does not currently set the source or target compability version inside build.gradle
+  # if you do not have Java 1.8 installed you cannot used the bottled version of Kafka
+  pour_bottle? do
+    reason "The bottle requires Java 1.8."
+    satisfy { quiet_system("/usr/libexec/java_home --version 1.8 --failfast") }
+  end
+
+  depends_on :java => "1.8"
+  depends_on "zookeeper"
+
+  def install
+    data = var/"lib"
+    inreplace "config/server.properties",
+      "log.dirs=/tmp/kafka-logs", "log.dirs=#{data}/kafka-logs"
+
+    inreplace "config/zookeeper.properties",
+      "dataDir=/tmp/zookeeper", "dataDir=#{data}/zookeeper"
+
+    # remove Windows scripts
+    rm_rf "bin/windows"
+
+    libexec.install "libs"
+
+    prefix.install "bin"
+    bin.env_script_all_files(libexec/"bin", Language::Java.java_home_env("1.8"))
+    Dir["#{bin}/*.sh"].each { |f| mv f, f.to_s.gsub(/.sh$/, "") }
+
+    mv "config", "kafka"
+    etc.install "kafka"
+    libexec.install_symlink etc/"kafka" => "config"
+
+    # create directory for kafka stdout+stderr output logs when run by launchd
+    (var+"log/kafka").mkpath
+  end
+
+  plist_options :manual => "zookeeper-server-start #{HOMEBREW_PREFIX}/etc/kafka/zookeeper.properties & kafka-server-start #{HOMEBREW_PREFIX}/etc/kafka/server.properties"
+
+  def plist; <<~EOS
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>WorkingDirectory</key>
+        <string>#{HOMEBREW_PREFIX}</string>
+        <key>ProgramArguments</key>
+        <array>
+            <string>#{opt_bin}/kafka-server-start</string>
+            <string>#{etc}/kafka/server.properties</string>
+        </array>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>KeepAlive</key>
+        <true/>
+        <key>StandardErrorPath</key>
+        <string>#{var}/log/kafka/kafka_output.log</string>
+        <key>StandardOutPath</key>
+        <string>#{var}/log/kafka/kafka_output.log</string>
+    </dict>
+    </plist>
+  EOS
+  end
+
+  test do
+    ENV["LOG_DIR"] = "#{testpath}/kafkalog"
+
+    (testpath/"kafka").mkpath
+    cp "#{etc}/kafka/zookeeper.properties", testpath/"kafka"
+    cp "#{etc}/kafka/server.properties", testpath/"kafka"
+    inreplace "#{testpath}/kafka/zookeeper.properties", "#{var}/lib", testpath
+    inreplace "#{testpath}/kafka/server.properties", "#{var}/lib", testpath
+
+    begin
+      fork do
+        exec "#{bin}/zookeeper-server-start #{testpath}/kafka/zookeeper.properties > #{testpath}/test.zookeeper-server-start.log 2>&1"
+      end
+
+      sleep 15
+
+      fork do
+        exec "#{bin}/kafka-server-start #{testpath}/kafka/server.properties > #{testpath}/test.kafka-server-start.log 2>&1"
+      end
+
+      sleep 30
+
+      system "#{bin}/kafka-topics --zookeeper localhost:2181 --create --if-not-exists --replication-factor 1 " \
+             "--partitions 1 --topic test > #{testpath}/kafka/demo.out 2>/dev/null"
+      pipe_output "#{bin}/kafka-console-producer --broker-list localhost:9092 --topic test 2>/dev/null",
+                  "test message"
+      system "#{bin}/kafka-console-consumer --bootstrap-server localhost:9092 --topic test --from-beginning " \
+             "--max-messages 1 >> #{testpath}/kafka/demo.out 2>/dev/null"
+      system "#{bin}/kafka-topics --zookeeper localhost:2181 --delete --topic test >> #{testpath}/kafka/demo.out " \
+             "2>/dev/null"
+    ensure
+      system "#{bin}/kafka-server-stop"
+      system "#{bin}/zookeeper-server-stop"
+      sleep 10
+    end
+
+    assert_match(/test message/, IO.read("#{testpath}/kafka/demo.out"))
+  end
+end

--- a/Formula/zookeeper@3.4.14.rb
+++ b/Formula/zookeeper@3.4.14.rb
@@ -1,0 +1,136 @@
+class Zookeeper < Formula
+  desc "Centralized server for distributed coordination of services"
+  homepage "https://zookeeper.apache.org/"
+  url "https://archive.apache.org/dist/zookeeper/zookeeper-3.4.14/zookeeper-3.4.14.tar.gz"
+  sha256 "b14f7a0fece8bd34c7fffa46039e563ac5367607c612517aa7bd37306afbd1cd"
+
+  bottle do
+    cellar :any
+    sha256 "854225ed94e18cdf9a08b992a658e851d4c4d77d826e8ae243488e65b38af84c" => :catalina
+    sha256 "e4cc87d3dc3d2e406fbc262b0b98bea4b8ab2464ca17c24b98abc92a055a4454" => :mojave
+    sha256 "6eceba9bba26dce645d2357f4fdca321b13bafb540c501f9b36f335695b450b1" => :high_sierra
+  end
+
+  head do
+    url "https://svn.apache.org/repos/asf/zookeeper/trunk"
+
+    depends_on "ant" => :build
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "cppunit" => :build
+    depends_on "libtool" => :build
+  end
+
+  def shim_script(target)
+    <<~EOS
+      #!/usr/bin/env bash
+      . "#{etc}/zookeeper/defaults"
+      cd "#{libexec}/bin"
+      ./#{target} "$@"
+    EOS
+  end
+
+  def default_zk_env
+    <<~EOS
+      [ -z "$ZOOCFGDIR" ] && export ZOOCFGDIR="#{etc}/zookeeper"
+    EOS
+  end
+
+  def default_log4j_properties
+    <<~EOS
+      log4j.rootCategory=WARN, zklog
+      log4j.appender.zklog = org.apache.log4j.RollingFileAppender
+      log4j.appender.zklog.File = #{var}/log/zookeeper/zookeeper.log
+      log4j.appender.zklog.Append = true
+      log4j.appender.zklog.layout = org.apache.log4j.PatternLayout
+      log4j.appender.zklog.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n
+    EOS
+  end
+
+  def install
+    if build.head?
+      system "ant", "compile_jute"
+      system "autoreconf", "-fvi", "src/c"
+    end
+
+    cd "zookeeper-client/zookeeper-client-c" do
+      system "./configure", "--disable-dependency-tracking",
+                            "--prefix=#{prefix}",
+                            "--without-cppunit"
+      system "make", "install"
+    end
+
+    rm_f Dir["bin/*.cmd"]
+
+    if build.head?
+      system "ant"
+      libexec.install "bin", "src/contrib", "src/java/lib"
+      libexec.install Dir["build/*.jar"]
+    else
+      libexec.install "bin", "zookeeper-contrib", "lib"
+      libexec.install Dir["*.jar"]
+    end
+
+    bin.mkpath
+    (etc/"zookeeper").mkpath
+    (var/"log/zookeeper").mkpath
+    (var/"run/zookeeper/data").mkpath
+
+    Pathname.glob("#{libexec}/bin/*.sh") do |path|
+      next if path == libexec+"bin/zkEnv.sh"
+
+      script_name = path.basename
+      bin_name    = path.basename ".sh"
+      (bin+bin_name).write shim_script(script_name)
+    end
+
+    defaults = etc/"zookeeper/defaults"
+    defaults.write(default_zk_env) unless defaults.exist?
+
+    log4j_properties = etc/"zookeeper/log4j.properties"
+    log4j_properties.write(default_log4j_properties) unless log4j_properties.exist?
+
+    inreplace "conf/zoo_sample.cfg",
+              /^dataDir=.*/, "dataDir=#{var}/run/zookeeper/data"
+    cp "conf/zoo_sample.cfg", "conf/zoo.cfg"
+    (etc/"zookeeper").install ["conf/zoo.cfg", "conf/zoo_sample.cfg"]
+  end
+
+  plist_options :manual => "zkServer start"
+
+  def plist; <<~EOS
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+      <dict>
+        <key>EnvironmentVariables</key>
+        <dict>
+           <key>SERVER_JVMFLAGS</key>
+           <string>-Dapple.awt.UIElement=true</string>
+        </dict>
+        <key>KeepAlive</key>
+        <dict>
+          <key>SuccessfulExit</key>
+          <false/>
+        </dict>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>ProgramArguments</key>
+        <array>
+          <string>#{opt_bin}/zkServer</string>
+          <string>start-foreground</string>
+        </array>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>WorkingDirectory</key>
+        <string>#{var}</string>
+      </dict>
+    </plist>
+  EOS
+  end
+
+  test do
+    output = shell_output("#{bin}/zkServer -h 2>&1")
+    assert_match "Using config: #{etc}/zookeeper/zoo.cfg", output
+  end
+end


### PR DESCRIPTION
These are needed for `setup_kafka_and_zookeeper.sh`:
```bash
  # zookeeper 3.4.14
  is_expected_version_installed 'zookeeper' '3.4.14' || {
    echo 'installing zookeeper v3.4.14'
    brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/6d8197bbb5f77e62d51041a3ae552ce2f8ff1344/Formula/zookeeper.rb
  }

  # kafka 2.3.0
  # without `--no-dependencies` `brew` installs a modern (not backwards compatible) version of
  # zookeeper, ignoring the specific 3.4.14 version we just installed
  is_expected_version_installed 'kafka' '2.3.0' || {
    echo 'installing kafka v2.3.0'
    brew install --ignore-dependencies https://raw.githubusercontent.com/Homebrew/homebrew-core/6d8197bbb5f77e62d51041a3ae552ce2f8ff1344/Formula/kafka.rb
  }
```

Now that it's impossible to run `brew install <url>`, commit these two urls to our repo. These files were copied from these URLs:

- https://raw.githubusercontent.com/Homebrew/homebrew-core/6d8197bbb5f77e62d51041a3ae552ce2f8ff1344/Formula/zookeeper.rb
- https://raw.githubusercontent.com/Homebrew/homebrew-core/6d8197bbb5f77e62d51041a3ae552ce2f8ff1344/Formula/kafka.rb

Then, we can install them with `brew install kafka@2.3.0` and `brew install zookeeper@3.4.14`.

cc @nelsonomuto @daniel-vetter-opendoor 