### PR TITLE
elasticsearch: replace now-deprecated java

### DIFF
--- a/Formula/elasticsearch@1.7.rb
+++ b/Formula/elasticsearch@1.7.rb
@@ -9,7 +9,7 @@ class ElasticsearchAT17 < Formula
 
   keg_only :versioned_formula
 
-  depends_on :java => "1.7+"
+  depends_on "openjdk@8"
 
   def cluster_name
     "elasticsearch_#{ENV["USER"]}"

--- a/Formula/elasticsearch@2.4.rb
+++ b/Formula/elasticsearch@2.4.rb
@@ -11,7 +11,7 @@ class ElasticsearchAT24 < Formula
 
   deprecate! :date => "2018-02-28", :because => :deprecated_upstream
 
-  depends_on :java => "1.8"
+  depends_on "openjdk@8"
 
   def cluster_name
     "elasticsearch_#{ENV["USER"]}"

--- a/README.md
+++ b/README.md
@@ -19,3 +19,20 @@ $ brew install gothumb
 # if you've installed homebrew-services:
 $ brew services start gothumb
 ```
+
+## Development
+
+To test changes put up a branch/PR then `cd` to the local version of this repo installed by `homebrew tap 'opendoor-labs/tap'`:
+
+```shell
+> cd /usr/local/Homebrew/Library/Taps/opendoor-labs/homebrew-tap
+```
+
+This directory is a `git` repository corresponding to this repo so `git pull` then checkout your branch:
+
+```shell
+> git pull
+> git checkout <your-branch-here>
+```
+
+Then run whatever `brew` commands you want with any changes to formula applied.


### PR DESCRIPTION
Test if openjdk@8 will work for our two elasticsearch versions

[Slack thread](https://opendoor.slack.com/archives/CCBKYV1E0/p1606954224137400)
[2.6 release notes mentioning deprecation](https://brew.sh/2020/12/01/homebrew-2.6.0/)
