### PR TITLE
es 2.4: depend on openjdk rather than java 1.8

### DIFF
--- a/Formula/elasticsearch@2.4.rb
+++ b/Formula/elasticsearch@2.4.rb
@@ -11,7 +11,7 @@ class ElasticsearchAT24 < Formula
 
   deprecate! :date => "2018-02-28", :because => :deprecated_upstream
 
-  depends_on :java => "1.8"
+  depends_on "openjdk@8"
 
   def cluster_name
     "elasticsearch_#{ENV["USER"]}"


### PR DESCRIPTION
When running the web `bin/server` script, I saw the
following warning:

```
Warning: Calling depends_on :java is deprecated! Use "depends_on "openjdk@11", "depends_on "openjdk@8" or "depends_on "openjdk" instead.
Please report this issue to the opendoor-labs/tap tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/opendoor-labs/homebrew-tap/Formula/elasticsearch@2.4.rb:14
```

so I thought I would do what it suggested and open a PR to fix it.