### PR TITLE
Replace deprecated :java with openjdk in kafka Formula

### DIFF
--- a/Formula/kafka.rb
+++ b/Formula/kafka.rb
@@ -19,7 +19,7 @@ class Kafka < Formula
     satisfy { quiet_system("/usr/libexec/java_home --version 1.8 --failfast") }
   end
 
-  depends_on :java => "1.8"
+  depends_on "openjdk@8"
   depends_on "zookeeper"
 
   def install


### PR DESCRIPTION
The same change as https://github.com/opendoor-labs/homebrew-tap/pull/25 and https://github.com/opendoor-labs/homebrew-tap/pull/26

I'm installing `code` on a brand new laptop and getting:
```
❯ $GOPATH/src/github.com/opendoor-labs/code/scripts/development/setup.sh
Installing brew dependencies...
Using homebrew/cask-versions
==> Tapping opendoor-labs/tap
Cloning into '/usr/local/Homebrew/Library/Taps/opendoor-labs/homebrew-tap'...
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/opendoor-labs/homebrew-tap/Formula/kafka.rb
kafka: Calling depends_on :java is disabled! Use "depends_on "openjdk@11", "depends_on "openjdk@8" or "depends_on "openjdk" instead.
Please report this issue to the opendoor-labs/tap tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/opendoor-labs/homebrew-tap/Formula/kafka.rb:22
Error: Cannot tap opendoor-labs/tap: invalid syntax in tap!
```

Which appears to be caused by Homebrew 2.6.0 (released 2020-12-01) [deprecating :java](https://brew.sh/2020/12/01/homebrew-2.6.0/) (ty @nathanshelly for that find) 