### PR TITLE
bottle: fix sha256 cellar thing

### DIFF
--- a/Formula/helm@2.13.rb
+++ b/Formula/helm@2.13.rb
@@ -7,10 +7,9 @@ class HelmAT213 < Formula
   head "https://github.com/helm/helm.git"
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "30f412ad5b85b63edbd373cfca01fd51530ebcac9d38293725b05c04b97cc8b0" => :mojave
-    sha256 "040fe1324e5129750d5d4c1a4cc233f8398f6ef6a368eb83cfc7bd10e785f4d8" => :high_sierra
-    sha256 "09897c4363a5f8aea65a1159aca38df674fd6564bcb90a6243232e555cdbb617" => :sierra
+    sha256 cellar: :any_skip_relocation, mojave:      "30f412ad5b85b63edbd373cfca01fd51530ebcac9d38293725b05c04b97cc8b0"
+    sha256 cellar: :any_skip_relocation, high_sierra: "040fe1324e5129750d5d4c1a4cc233f8398f6ef6a368eb83cfc7bd10e785f4d8"
+    sha256 cellar: :any_skip_relocation, sierra:      "09897c4363a5f8aea65a1159aca38df674fd6564bcb90a6243232e555cdbb617"
   end
 
   depends_on "glide" => :build

--- a/Formula/kafka.rb
+++ b/Formula/kafka.rb
@@ -5,10 +5,9 @@ class Kafka < Formula
   sha256 "d86f5121a9f0c44477ae6b6f235daecc3f04ecb7bf98596fd91f402336eee3e7"
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "1483beca512a1121491d8890290826e80f87d6630c37b15207db1d0cf39c805c" => :mojave
-    sha256 "1483beca512a1121491d8890290826e80f87d6630c37b15207db1d0cf39c805c" => :high_sierra
-    sha256 "84e51f5c33a35333e3da125076fa9f566e647ff9a555716ac478123a81d4186b" => :sierra
+    sha256 cellar: :any_skip_relocation, mojave:      "1483beca512a1121491d8890290826e80f87d6630c37b15207db1d0cf39c805c"
+    sha256 cellar: :any_skip_relocation, high_sierra: "1483beca512a1121491d8890290826e80f87d6630c37b15207db1d0cf39c805c"
+    sha256 cellar: :any_skip_relocation, sierra:      "84e51f5c33a35333e3da125076fa9f566e647ff9a555716ac478123a81d4186b"
   end
 
   # Related to https://issues.apache.org/jira/browse/KAFKA-2034

--- a/Formula/postgis-2.2.2.rb
+++ b/Formula/postgis-2.2.2.rb
@@ -6,10 +6,9 @@ class Postgis222 < Formula
   revision 3
 
   bottle do
-    cellar :any
-    sha256 "9eb30b316b0cdc052238da3a7ce7a3a4dc0b90c3ff2c5a45b83c312047343e14" => :sierra
-    sha256 "d47407dcfa0c653783a5e4115b25b5d1da43950cad79b011f30654ad6c9fdd98" => :el_capitan
-    sha256 "cd71f9fb9684f5e45fabeed09fb82f46541233b8fdc07ee0305fd7b4e1fc20f5" => :yosemite
+    sha256 cellar: :any, sierra:     "9eb30b316b0cdc052238da3a7ce7a3a4dc0b90c3ff2c5a45b83c312047343e14"
+    sha256 cellar: :any, el_capitan: "d47407dcfa0c653783a5e4115b25b5d1da43950cad79b011f30654ad6c9fdd98"
+    sha256 cellar: :any, yosemite:   "cd71f9fb9684f5e45fabeed09fb82f46541233b8fdc07ee0305fd7b4e1fc20f5"
   end
 
   head do

--- a/Formula/vowpal-wabbit-8.2.1.rb
+++ b/Formula/vowpal-wabbit-8.2.1.rb
@@ -6,11 +6,10 @@ class VowpalWabbit821 < Formula
   head "https://github.com/JohnLangford/vowpal_wabbit.git"
 
   bottle do
-    cellar :any
-    sha256 "b4b2e46f945a6886ce72d1cccabd8ea7639fb4057385de09b6faf34fbd35a363" => :sierra
-    sha256 "369dbd0266e777f4fa9ab2d31b216974cef013f3ad79307dcd93eea7584dffe6" => :el_capitan
-    sha256 "9180ead040a4daf5727d18328f39e82aa33fe6b684d4366502462449999f70fd" => :yosemite
-    sha256 "3ba964d1da671f6f88e1f2a2d8509ed190f5b02ce1c19f5bbbccac24a1f709d6" => :mavericks
+    sha256 cellar: :any, sierra:     "b4b2e46f945a6886ce72d1cccabd8ea7639fb4057385de09b6faf34fbd35a363"
+    sha256 cellar: :any, el_capitan: "369dbd0266e777f4fa9ab2d31b216974cef013f3ad79307dcd93eea7584dffe6"
+    sha256 cellar: :any, yosemite:   "9180ead040a4daf5727d18328f39e82aa33fe6b684d4366502462449999f70fd"
+    sha256 cellar: :any, mavericks:  "3ba964d1da671f6f88e1f2a2d8509ed190f5b02ce1c19f5bbbccac24a1f709d6"
   end
 
   if MacOS.version < :mavericks

--- a/Formula/vowpal-wabbit.rb
+++ b/Formula/vowpal-wabbit.rb
@@ -5,11 +5,10 @@ class VowpalWabbit < Formula
   sha256 "452c3e83b73fd67f5e9cfae8bfbaf398cda73dc688186b376e6106c376ec5eb1"
 
   bottle do
-    cellar :any
-    sha256 "de51b144ef201d85cb2ff3edc21e4903186a5acf890fbe2032c1ae405cd61e18" => :mojave
-    sha256 "48a939d6399a4ad1ed2f3f0babd8d7a9edc5a6e801683b5b06f12b5f0daf5d55" => :high_sierra
-    sha256 "18283653fa6b9fdfafdf1361a86b43bf1f56a609934499e0f31634b960b69862" => :sierra
-    sha256 "23598d455b5a62bdf8f65df7b266b07be980738cfe69f664e5f1cb110ec72cf1" => :el_capitan
+    sha256 cellar: :any, mojave:      "de51b144ef201d85cb2ff3edc21e4903186a5acf890fbe2032c1ae405cd61e18"
+    sha256 cellar: :any, high_sierra: "48a939d6399a4ad1ed2f3f0babd8d7a9edc5a6e801683b5b06f12b5f0daf5d55"
+    sha256 cellar: :any, sierra:      "18283653fa6b9fdfafdf1361a86b43bf1f56a609934499e0f31634b960b69862"
+    sha256 cellar: :any, el_capitan:  "23598d455b5a62bdf8f65df7b266b07be980738cfe69f664e5f1cb110ec72cf1"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/zookeeper.rb
+++ b/Formula/zookeeper.rb
@@ -5,10 +5,9 @@ class Zookeeper < Formula
   sha256 "b14f7a0fece8bd34c7fffa46039e563ac5367607c612517aa7bd37306afbd1cd"
 
   bottle do
-    cellar :any
-    sha256 "854225ed94e18cdf9a08b992a658e851d4c4d77d826e8ae243488e65b38af84c" => :catalina
-    sha256 "e4cc87d3dc3d2e406fbc262b0b98bea4b8ab2464ca17c24b98abc92a055a4454" => :mojave
-    sha256 "6eceba9bba26dce645d2357f4fdca321b13bafb540c501f9b36f335695b450b1" => :high_sierra
+    sha256 cellar: :any, catalina:    "854225ed94e18cdf9a08b992a658e851d4c4d77d826e8ae243488e65b38af84c"
+    sha256 cellar: :any, mojave:      "e4cc87d3dc3d2e406fbc262b0b98bea4b8ab2464ca17c24b98abc92a055a4454"
+    sha256 cellar: :any, high_sierra: "6eceba9bba26dce645d2357f4fdca321b13bafb540c501f9b36f335695b450b1"
   end
 
   head do


### PR DESCRIPTION
Bug:
```
brew tap opendoor-labs/tap

==> Tapping opendoor-labs/tap
Cloning into '/usr/local/Homebrew/Library/Taps/opendoor-labs/homebrew-tap'...
remote: Enumerating objects: 259, done.
remote: Counting objects: 100% (39/39), done.
remote: Compressing objects: 100% (32/32), done.
remote: Total 259 (delta 9), reused 26 (delta 7), pack-reused 220
Receiving objects: 100% (259/259), 54.60 KiB | 594.00 KiB/s, done.
Resolving deltas: 100% (93/93), done.
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/opendoor-labs/homebrew-tap/Formula/postgis-2.2.2.rb
postgis-2.2.2: Calling `cellar` in a bottle block is disabled! Use `brew style --fix` on the formula to update the style or use `sha256` with a `cellar:` argument instead.
Please report this issue to the opendoor-labs/tap tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/opendoor-labs/homebrew-tap/Formula/postgis-2.2.2.rb:9
 ...
```

To fix, I ran this:
```
brew style --fix postgis-2.2.2.rb kafka.rb vowpal-wabbit.rb zookeeper.rb helm@2.13.rb vowpal-wabbit-8.2.1.rb
```
Then, I only committed the changes that fix the `cellar` issue homebrew was talking about.

