### PR TITLE
dexter: pin to go@1.17 to fix 1.18 build error

### DIFF
--- a/Formula/dexter.rb
+++ b/Formula/dexter.rb
@@ -6,6 +6,8 @@ class Dexter < Formula
       :tag      => "v0.7.1",
       :revision => "9a3c20c119f1a2a0aa55fdbf488828edaa338178"
   head "git@github.com:opendoor-labs/dexter"
+  # work around "//go:linkname must refer to declared function or variable" error
+  # until our version of dexter can compile on go 1.18+
   depends_on "go@1.17" => :build
 
   def install

--- a/Formula/dexter.rb
+++ b/Formula/dexter.rb
@@ -6,7 +6,7 @@ class Dexter < Formula
       :tag      => "v0.7.1",
       :revision => "9a3c20c119f1a2a0aa55fdbf488828edaa338178"
   head "git@github.com:opendoor-labs/dexter"
-  depends_on "go" => :build
+  depends_on "go@1.17" => :build
 
   def install
     ENV["GOPATH"] = buildpath


### PR DESCRIPTION
<!-- Content enclosed in HTML comments will not be rendered in the Markdown, and are intended to help guide you -->

## Context

`go` recently updated from 1.17 to 1.18, which is causing build errors in dexter:

```
brew install dexter
...
golang.org/x/sys/unix
../go/pkg/mod/golang.org/x/sys@v0.0.0-20200803210538-64077c9b5642/unix/syscall_darwin.1_13.go:29:3: //go:linkname must refer to declared function or variable
../go/pkg/mod/golang.org/x/sys@v0.0.0-20200803210538-64077c9b5642/unix/zsyscall_darwin_amd64.1_13.go:27:3: //go:linkname must refer to declared function or variable
....
../go/pkg/mod/golang.org/x/sys@v0.0.0-20200803210538-64077c9b5642/unix/zsyscall_darwin_amd64.go:121:3: too many errors
make: *** [bin/amd64/dexter] Error 2
```

What does it mean? Who knows, let's just fix it by pinning to go 1.17 while @leochu is out.

## Origin

Me, conversation with @samuelshih in https://opendoor.slack.com/archives/C02JDK7BQ77/p1648152254195219 and @dioant 

Related: https://opendoor.atlassian.net/servicedesk/customer/portal/46/OSEC-2157

## Summary of Changes

- dexter.rb: depend on go@1.17. This makes it so that version of `go` is the only one available in your $PATH when compiling

## Test Plan

```
brew uninstall dexter
brew install /Users/brian.malehorn/homebrew-tap/Formula/dexter.rb
dexter version
```

Before
```
Error: Failed to load cask: /Users/brian.malehorn/homebrew-tap/Formula/dexter.rb
Cask 'dexter' is unreadable: wrong constant name #<Class:0x0000000154217c30>
Warning: Treating /Users/brian.malehorn/homebrew-tap/Formula/dexter.rb as a formula.
==> Cloning git@github.com:opendoor-labs/dexter
Updating /Users/brian.malehorn/Library/Caches/Homebrew/dexter--git
==> Checking out tag v0.7.1
HEAD is now at 9a3c20c Merge pull request #4 from opendoor-labs/modules
HEAD is now at 9a3c20c Merge pull request #4 from opendoor-labs/modules
==> make ARTIFACT=/opt/homebrew/Cellar/dexter/0.7.1/bin/dexter OS=darwin BASE_VERSION=0.7.1
Last 15 lines from /Users/brian.malehorn/Library/Logs/Homebrew/dexter/01.make:
../../../../pkg/mod/golang.org/x/sys@v0.0.0-20200803210538-64077c9b5642/unix/zsyscall_darwin_arm64.go:75:3: //go:linkname must refer to declared function or variable
../../../../pkg/mod/golang.org/x/sys@v0.0.0-20200803210538-64077c9b5642/unix/zsyscall_darwin_arm64.go:90:3: //go:linkname must refer to declared function or variable
../../../../pkg/mod/golang.org/x/sys@v0.0.0-20200803210538-64077c9b5642/unix/zsyscall_darwin_arm64.go:105:3: //go:linkname must refer to declared function or variable
../../../../pkg/mod/golang.org/x/sys@v0.0.0-20200803210538-64077c9b5642/unix/zsyscall_darwin_arm64.go:121:3: //go:linkname must refer to declared function or variable
../../../../pkg/mod/golang.org/x/sys@v0.0.0-20200803210538-64077c9b5642/unix/zsyscall_darwin_arm64.go:121:3: too many errors
github.com/spf13/cobra
github.com/coreos/go-oidc/v3/oidc
gopkg.in/square/go-jose.v2/jwt
golang.org/x/net/idna
golang.org/x/net/http/httpguts
golang.org/x/net/http2
github.com/hashicorp/vault/api
make: *** [bin/amd64/dexter] Error 2
make: *** Waiting for unfinished jobs....
make: *** [vet] Error 2

Do not report this issue to Homebrew/brew or Homebrew/core!

dexter version
fish: Unknown command: dexter
```

After
```
brew install /Users/brian.malehorn/homebrew-tap/Formula/dexter.rb
Error: Failed to load cask: /Users/brian.malehorn/homebrew-tap/Formula/dexter.rb
Cask 'dexter' is unreadable: wrong constant name #<Class:0x0000000121a14b00>
Warning: Treating /Users/brian.malehorn/homebrew-tap/Formula/dexter.rb as a formula.
==> Cloning git@github.com:opendoor-labs/dexter
Updating /Users/brian.malehorn/Library/Caches/Homebrew/dexter--git
==> Checking out tag v0.7.1
HEAD is now at 9a3c20c Merge pull request #4 from opendoor-labs/modules
HEAD is now at 9a3c20c Merge pull request #4 from opendoor-labs/modules
==> make ARTIFACT=/opt/homebrew/Cellar/dexter/0.7.1/bin/dexter OS=darwin BASE_VERSION=0.7.1
🍺  /opt/homebrew/Cellar/dexter/0.7.1: 5 files, 10.9MB, built in 7 seconds
==> Running `brew cleanup dexter`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).

dexter version
    .___               __                
  __| _/____ ___  ____/  |_  ___________ 
 / __ |/ __ \\  \/  /\   __\/ __ \_  __ \
/ /_/ \  ___/ >    <  |  | \  ___/|  | \/
\____ |\___  >__/\_ \ |__|  \___  >__|   
     \/    \/      \/           \/       

Version    : 0.7.1.v0.7.1
Git Hash   : v0.7.1
Birth Date : 1648164896
```

<!-- How have you tested this change, and what further testing will be done? What’s the riskiest part of this PR? How will you test and monitor that? -->

## Checklist

<!-- This is a checklist. To mark an item as complete, use [x]. See https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#task-lists -->

- [x] I have commented my code, particularly in hard-to-understand areas

<!-- This PR template is inherited from https://github.com/opendoor-labs/.github -->
