### PR TITLE
dexter: update, use latest go (1.18)

### DIFF
--- a/Formula/dexter.rb
+++ b/Formula/dexter.rb
@@ -6,7 +6,7 @@ class Dexter < Formula
       :tag      => "v0.7.1",
       :revision => "9a3c20c119f1a2a0aa55fdbf488828edaa338178"
   head "git@github.com:opendoor-labs/dexter"
-  depends_on "go@1.17" => :build
+  depends_on "go" => :build
 
   def install
     ENV["GOPATH"] = buildpath

--- a/Formula/dexter.rb
+++ b/Formula/dexter.rb
@@ -3,8 +3,8 @@ class Dexter < Formula
   homepage "https://github.com/opendoor-labs/dexter"
   url "git@github.com:opendoor-labs/dexter",
       :using    => :git,
-      :tag      => "v0.7.1",
-      :revision => "9a3c20c119f1a2a0aa55fdbf488828edaa338178"
+      :tag      => "v0.7.2",
+      :revision => "43a8e1d036d2e33065cfb3edf573a4745a5535b5"
   head "git@github.com:opendoor-labs/dexter"
   depends_on "go" => :build
 

--- a/Formula/dexter.rb
+++ b/Formula/dexter.rb
@@ -6,8 +6,6 @@ class Dexter < Formula
       :tag      => "v0.7.1",
       :revision => "9a3c20c119f1a2a0aa55fdbf488828edaa338178"
   head "git@github.com:opendoor-labs/dexter"
-  # work around "//go:linkname must refer to declared function or variable" error
-  # until our version of dexter can compile on go 1.18+
   depends_on "go@1.17" => :build
 
   def install


### PR DESCRIPTION
<!-- Content enclosed in HTML comments will not be rendered in the Markdown, and are intended to help guide you -->

## Context

We've fixed the build issue with dexter + go 1.18 in https://github.com/opendoor-labs/dexter/pull/5.
So revert stopgap #32 and update dexter to the latest version.

## Origin

Me, fix from @leochu 

## Summary of Changes

- dexter.rb: revert #32 and update to latest dexter

## Test Plan

```
brew uninstall dexter
brew install /Users/brian.malehorn/homebrew-tap/Formula/dexter.rb
```
```
Running `brew update --preinstall`...
==> Auto-updated Homebrew!
Updated 1 tap (homebrew/core).
==> Updated Formulae
Updated 9 formulae.

Error: Failed to load cask: /Users/brian.malehorn/homebrew-tap/Formula/dexter.rb
Cask 'dexter' is unreadable: wrong constant name #<Class:0x000000013121bf88>
Warning: Treating /Users/brian.malehorn/homebrew-tap/Formula/dexter.rb as a formula.
==> Cloning git@github.com:opendoor-labs/dexter
Updating /Users/brian.malehorn/Library/Caches/Homebrew/dexter--git
From github.com:opendoor-labs/dexter
 * [new tag]         v0.7.2     -> v0.7.2
==> Checking out tag v0.7.2
Previous HEAD position was 9a3c20c Merge pull request #4 from opendoor-labs/modules
HEAD is now at 43a8e1d Update golang/x/sys package (#5)
HEAD is now at 43a8e1d Update golang/x/sys package (#5)
==> make ARTIFACT=/opt/homebrew/Cellar/dexter/0.7.2/bin/dexter OS=darwin BASE_VERSION=0.7.2
🍺  /opt/homebrew/Cellar/dexter/0.7.2: 5 files, 11.2MB, built in 12 seconds
==> Running `brew cleanup dexter`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
```

## Checklist

<!-- This is a checklist. To mark an item as complete, use [x]. See https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#task-lists -->

- [x] I have commented my code, particularly in hard-to-understand areas
