### PR TITLE
elasticsearch@2.4: remove now-failing bottle :unneeded

### DIFF
--- a/Formula/elasticsearch@2.4.rb
+++ b/Formula/elasticsearch@2.4.rb
@@ -9,8 +9,6 @@ class ElasticsearchAT24 < Formula
 
   deprecate! :date => "2018-02-28", :because => :deprecated_upstream
 
-  depends_on "openjdk@8"
-
   def cluster_name
     "elasticsearch_#{ENV["USER"]}"
   end

--- a/Formula/elasticsearch@2.4.rb
+++ b/Formula/elasticsearch@2.4.rb
@@ -5,8 +5,6 @@ class ElasticsearchAT24 < Formula
   sha256 "5f7e4bb792917bb7ffc2a5f612dfec87416d54563f795d6a70637befef4cfc6f"
   revision 1
 
-  bottle :unneeded
-
   keg_only :versioned_formula
 
   deprecate! :date => "2018-02-28", :because => :deprecated_upstream


### PR DESCRIPTION
<!-- Content enclosed in HTML comments will not be rendered in the Markdown, and are intended to help guide you -->

## Context

Fix `elasticsearch@2.4` formula. This error was pointed out by @zabil trying to set up his own development:

```
brew install elasticsearch@2.4
Installing elasticsearch@2.4
Warning: 'elasticsearch@2.4' formula is unreadable: elasticsearch@2.4: wrong number of arguments (given 1, expected 0)
Error: elasticsearch@2.4: wrong number of arguments (given 1, expected 0)
```

I debugged this by adding print statements to `/usr/local/Homebrew/Library/Taps/opendoor-labs/homebrew-tap/Formula/elasticsearch@2.4.rb`, eventually leading to the line `bottle :unneeded` as throwing the error. I recall this giving a warning in the past that it's no longer necessary, so simply remove it to get it installing again.

Also remove the dependency on openjdk@8, which is no longer available as a tap. Elasticsearch still seems to install run & just fine.

https://opendoor.atlassian.net/browse/INFRA-3482

## Test Plan

```
brew uninstall dexter
brew untap opendoor-labs/homebrew-tap
brew install /usr/local/Homebrew/Library/Taps/opendoor-labs/homebrew-tap/Formula/elasticsearch@2.4.rb
```

before:
```
Error: elasticsearch@2.4: wrong number of arguments (given 1, expected 0)
```

after:
```
Error: Failed to load cask: /usr/local/Homebrew/Library/Taps/opendoor-labs/homebrew-tap/Formula/elasticsearch@2.4.rb
Cask 'elasticsearch@2.4' is unreadable: wrong constant name #<Class:0x00000001469ff6b8>
Warning: Treating /usr/local/Homebrew/Library/Taps/opendoor-labs/homebrew-tap/Formula/elasticsearch@2.4.rb as a formula.
Warning: elasticsearch@2.4 has been deprecated because it is deprecated upstream!
==> Downloading https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.6/elasti
Already downloaded: /Users/brian.malehorn/Library/Caches/Homebrew/downloads/95ce423b5b1e1b65bcfdbc041ed3f6a6f2ada5492ab32c3d6e4e1dd1469de861--elasticsearch-2.4.6.tar.gz
==> Caveats
Data:    /opt/homebrew/var/elasticsearch/elasticsearch_brian.malehorn/
Logs:    /opt/homebrew/var/log/elasticsearch/elasticsearch_brian.malehorn.log
Plugins: /opt/homebrew/opt/elasticsearch@2.4/libexec/plugins/
Config:  /opt/homebrew/etc/elasticsearch/
plugin script: /opt/homebrew/opt/elasticsearch@2.4/libexec/bin/plugin

elasticsearch@2.4 is keg-only, which means it was not symlinked into /opt/homebrew,
because this is an alternate version of another formula.

If you need to have elasticsearch@2.4 first in your PATH, run:
  fish_add_path /opt/homebrew/opt/elasticsearch@2.4/bin


To restart elasticsearch@2.4 after an upgrade:
  brew services restart elasticsearch@2.4
Or, if you don't want/need a background service you can just run:
  /opt/homebrew/opt/elasticsearch@2.4/bin/elasticsearch
==> Summary
🍺  /opt/homebrew/Cellar/elasticsearch@2.4/2.4.6_1: 60 files, 29.1MB, built in 2 seconds
==> Running `brew cleanup elasticsearch@2.4`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
```



## Checklist

<!-- This is a checklist. To mark an item as complete, use [x]. See https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#task-lists -->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to external documentation if necessary (READMEs, Confluence, etc.)
- [ ] I have checked that other PRs this PR depends on have already been deployed.

<!-- This PR template is inherited from https://github.com/opendoor-labs/.github -->
