### PR TITLE
rdi: add dependencies on awscli, saml2aws, jq

### DIFF
--- a/Formula/rdi.rb
+++ b/Formula/rdi.rb
@@ -4,6 +4,9 @@ class Rdi < Formula
   
   url "git@github.com:opendoor-labs/rdi", using: :git, branch: "main"
   version "0.0.1"
+  depends_on "awscli"
+  depends_on "saml2aws"
+  depends_on "jq"
 
   def install
     libexec.install "rdi", "ec2_script.sh", "ssh_config"


### PR DESCRIPTION
<!-- Content enclosed in HTML comments will not be rendered in the Markdown, and are intended to help guide you -->

## Context

Instead of having `rdi` install them itself.
There's also the matter of `brew install --cask session-manager-plugin`, but I don't think a non-cask (aka CLI) package can depend on a cask one.

https://opendoor.atlassian.net/browse/INFRA-4181

## Test Plan

```
brew uninstall saml2aws awscli jq rdi; brew untap versent/homebrew-taps; brew install /Users/brian.malehorn/homebrew-tap/Formula/rdi.rb
```
```
Uninstalling /opt/homebrew/Cellar/saml2aws/2.36.0... (5 files, 14.2MB)
Uninstalling /opt/homebrew/Cellar/awscli/2.7.30... (12,662 files, 103.3MB)
Uninstalling /opt/homebrew/Cellar/jq/1.6... (18 files, 1.2MB)
Uninstalling /opt/homebrew/Cellar/rdi/0.0.1... (7 files, 25.5KB)
Untapping versent/taps...
Untapped 2 formulae (17 files, 64.8KB).
Error: Failed to load cask: /Users/brian.malehorn/homebrew-tap/Formula/rdi.rb
Cask 'rdi' is unreadable: wrong constant name #<Class:0x000000014f10aef0>
Warning: Treating /Users/brian.malehorn/homebrew-tap/Formula/rdi.rb as a formula.
==> Downloading https://ghcr.io/v2/homebrew/core/awscli/manifests/2.7.30
Already downloaded: /Users/brian.malehorn/Library/Caches/Homebrew/downloads/ded63dd206a570c5803f83a6c14c048c1d5cceb9e473fa8310ccffff753d5131--awscli-2.7.30.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/awscli/blobs/sha256:3c0a1c9279e2125ec8d5afb710cacb2592e3df02cf
Already downloaded: /Users/brian.malehorn/Library/Caches/Homebrew/downloads/c7a9c8b065090cf215b3f661faa1c8f97e6c53faa1d91282c236a314aa40b125--awscli--2.7.30.arm64_monterey.bottle.tar.gz
==> Downloading https://ghcr.io/v2/homebrew/core/saml2aws/manifests/2.36.0
Already downloaded: /Users/brian.malehorn/Library/Caches/Homebrew/downloads/3313f6ed874a815c8be4808ba2924f67fb79adbb20c0d6aae4cfbffa8d18d9e0--saml2aws-2.36.0.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/saml2aws/blobs/sha256:ae2cbe79a47d330536caab6ab21f6cba706fee72
Already downloaded: /Users/brian.malehorn/Library/Caches/Homebrew/downloads/cd3b4573a199f337a6db7eeb8e4ed4e8271f7d63f2dcec2a943f321daee6432e--saml2aws--2.36.0.arm64_monterey.bottle.tar.gz
==> Downloading https://ghcr.io/v2/homebrew/core/jq/manifests/1.6-1
######################################################################## 100.0%
==> Downloading https://ghcr.io/v2/homebrew/core/jq/blobs/sha256:f70e1ae8df182b242ca004492cc0a664e2a8195e2e46f3
==> Downloading from https://pkg-containers.githubusercontent.com/ghcr1/blobs/sha256:f70e1ae8df182b242ca004492c
######################################################################## 100.0%
==> Cloning git@github.com:opendoor-labs/rdi
Updating /Users/brian.malehorn/Library/Caches/Homebrew/rdi--git
==> Checking out branch main
Already on 'main'
Your branch is up to date with 'origin/main'.
HEAD is now at 78631e3 CODEOWNERS: add backend-infra as owner of everything
==> Installing dependencies for rdi: awscli, saml2aws and jq
==> Installing rdi dependency: awscli
==> Pouring awscli--2.7.30.arm64_monterey.bottle.tar.gz
🍺  /opt/homebrew/Cellar/awscli/2.7.30: 12,662 files, 103.3MB
==> Installing rdi dependency: saml2aws
==> Pouring saml2aws--2.36.0.arm64_monterey.bottle.tar.gz
🍺  /opt/homebrew/Cellar/saml2aws/2.36.0: 5 files, 14.2MB
==> Installing rdi dependency: jq
==> Pouring jq--1.6.arm64_monterey.bottle.1.tar.gz
🍺  /opt/homebrew/Cellar/jq/1.6: 18 files, 1.2MB
==> Installing rdi
🍺  /opt/homebrew/Cellar/rdi/0.0.1: 7 files, 25.5KB, built in 2 seconds
==> Running `brew cleanup rdi`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
```

