### PR TITLE
rdi: update to 0.0.2

### DIFF
--- a/Formula/rdi.rb
+++ b/Formula/rdi.rb
@@ -3,7 +3,7 @@ class Rdi < Formula
   homepage "https://github.com/opendoor-labs/rdi"
   
   url "git@github.com:opendoor-labs/rdi", using: :git, branch: "main"
-  version "0.0.1"
+  version "0.0.2"
   depends_on "awscli"
   depends_on "saml2aws"
   depends_on "jq"


### PR DESCRIPTION
<!-- Content enclosed in HTML comments will not be rendered in the Markdown, and are intended to help guide you -->

## Context

Bump `rdi` to include https://github.com/opendoor-labs/rdi/pull/1, https://github.com/opendoor-labs/rdi/pull/2, https://github.com/opendoor-labs/rdi/pull/3


## Test Plan

```
brew install /Users/brian.malehorn/homebrew-tap/Formula/rdi.rb
Error: Failed to load cask: /Users/brian.malehorn/homebrew-tap/Formula/rdi.rb
Cask 'rdi' is unreadable: wrong constant name #<Class:0x0000000140985738>
Warning: Treating /Users/brian.malehorn/homebrew-tap/Formula/rdi.rb as a formula.
rdi 0.0.1 is already installed but outdated (so it will be upgraded).
==> Cloning git@github.com:opendoor-labs/rdi
Updating /Users/brian.malehorn/Library/Caches/Homebrew/rdi--git
From github.com:opendoor-labs/rdi
   78631e3..5e8df73  main       -> origin/main
==> Checking out branch main
Already on 'main'
Your branch is behind 'origin/main' by 1 commit, and can be fast-forwarded.
HEAD is now at 5e8df73 upload_public_key: fix default SSH config bug (#1)
==> Upgrading rdi
  0.0.1 -> 0.0.2 

🍺  /opt/homebrew/Cellar/rdi/0.0.2: 7 files, 25.4KB, built in 3 seconds
==> Running `brew cleanup rdi`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
Removing: /opt/homebrew/Cellar/rdi/0.0.1... (7 files, 25.6KB)
```

