### PR TITLE
rdi: update to 0.0.4, adding rdi terminate

### DIFF
--- a/Formula/rdi.rb
+++ b/Formula/rdi.rb
@@ -2,8 +2,10 @@ class Rdi < Formula
   desc "Command-line tool 'rdi' to create and manage Remote Development Instances"
   homepage "https://github.com/opendoor-labs/rdi"
   
-  url "git@github.com:opendoor-labs/rdi", using: :git, branch: "main"
-  version "0.0.3"
+  url "git@github.com:opendoor-labs/rdi", 
+    using: :git,
+    revision: "2cb3014ad7dc91136a9338e73f4f3178f03ea707"
+  version "0.0.4"
   depends_on "awscli"
   depends_on "saml2aws"
   depends_on "jq"


### PR DESCRIPTION
<!-- Content enclosed in HTML comments will not be rendered in the Markdown, and are intended to help guide you -->

## Context

Update with https://github.com/opendoor-labs/rdi/pull/6.

Also pass in `revision: "2cb3014ad7dc91136a9338e73f4f3178f03ea707"` instead of `branch: "master"`. This way:

* new commits to `rdi` won't randomly get installed for some people (people who run `brew install rdi` for the first time) but not others (people who are already on 0.0.4)
* we can install old versions of `rdi` by referencing old versions of this file

https://opendoor.atlassian.net/browse/INFRA-4220

## Test Plan

N/A

## Checklist

N/A
