### PR TITLE
rdi: update to 0.0.5, fixing saml2aws login

### DIFF
--- a/Formula/rdi.rb
+++ b/Formula/rdi.rb
@@ -4,8 +4,8 @@ class Rdi < Formula
   
   url "git@github.com:opendoor-labs/rdi", 
     using: :git,
-    revision: "2cb3014ad7dc91136a9338e73f4f3178f03ea707"
-  version "0.0.4"
+    revision: "db1962cba253f8656f1b9001cad995c85a642466"
+  version "0.0.5"
   depends_on "awscli"
   depends_on "saml2aws"
   depends_on "jq"


### PR DESCRIPTION
<!-- Content enclosed in HTML comments will not be rendered in the Markdown, and are intended to help guide you -->

## Context

https://github.com/opendoor-labs/rdi/pull/7
https://opendoor.atlassian.net/browse/INFRA-4247

## Test Plan

```
brew uninstall rdi ; brew install /Users/brian.malehorn/homebrew-tap/Formula/rdi.rb
```
