### PR TITLE
rdi: update to 0.0.6, fixing reference

### DIFF
--- a/Formula/rdi.rb
+++ b/Formula/rdi.rb
@@ -4,8 +4,8 @@ class Rdi < Formula
   
   url "git@github.com:opendoor-labs/rdi", 
     using: :git,
-    revision: "db1962cba253f8656f1b9001cad995c85a642466"
-  version "0.0.5"
+    revision: "2cb3014ad7dc91136a9338e73f4f3178f03ea707"
+  version "0.0.6"
   depends_on "awscli"
   depends_on "saml2aws"
   depends_on "jq"


### PR DESCRIPTION
<!-- Content enclosed in HTML comments will not be rendered in the Markdown, and are intended to help guide you -->

## Context

Fix the reference to point to `origin/main`, instead of the reference of my branch that was squashed and merged. Homebrew won't pull in all references on github unless they have a branch associated with it - and my personal checkout had this reference which is why it was working for me.

I should probably update this to install based on tag but let's just fix it for now.

https://opendoor.slack.com/archives/C02BX2V0Y75/p1663337204973359
https://opendoor.atlassian.net/browse/INFRA-4255


## Test Plan

```
brew install rdi
```


