### PR TITLE
rdi: upgrade to v0.0.7, switch to tag-based instead of hash-based versions

### DIFF
--- a/Formula/rdi.rb
+++ b/Formula/rdi.rb
@@ -4,8 +4,8 @@ class Rdi < Formula
   
   url "git@github.com:opendoor-labs/rdi", 
     using: :git,
-    revision: "2cb3014ad7dc91136a9338e73f4f3178f03ea707"
-  version "0.0.6"
+    tag: "v0.0.7"
+  version "0.0.7"
   depends_on "awscli"
   depends_on "saml2aws"
   depends_on "jq"


### PR DESCRIPTION


<!-- Content enclosed in HTML comments will not be rendered in the Markdown, and are intended to help guide you -->

## Context

https://github.com/opendoor-labs/rdi/pull/9

https://opendoor.atlassian.net/browse/INFRA-4207

## Test Plan

```
brew uninstall rdi ; brew install /Users/brian.malehorn/homebrew-tap/Formula/rdi.rb
```
## Checklist

- [x] update v0.0.7 tag
- [x] run test plan after merge
