### PR TITLE
rdi: upgrade to v0.0.8, fixing sessionmanager installation

### DIFF
--- a/Formula/rdi.rb
+++ b/Formula/rdi.rb
@@ -4,8 +4,8 @@ class Rdi < Formula
   
   url "git@github.com:opendoor-labs/rdi", 
     using: :git,
-    tag: "v0.0.7"
-  version "0.0.7"
+    tag: "v0.0.8"
+  version "0.0.8"
   depends_on "awscli"
   depends_on "saml2aws"
   depends_on "jq"


### PR DESCRIPTION
<!-- Content enclosed in HTML comments will not be rendered in the Markdown, and are intended to help guide you -->

## Context

Apply https://github.com/opendoor-labs/rdi/pull/10.

https://opendoor.atlassian.net/browse/INFRA-4310

## Test Plan

- [x] merge in https://github.com/opendoor-labs/rdi/pull/10
- [x] tag it with v0.0.8
- [x] `brew uninstall rdi ; brew install /Users/brian.malehorn/homebrew-tap/Formula/rdi.rb`
